### PR TITLE
Simplifies release task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,11 +48,8 @@ cyclonedxBom {
     schemaVersion = "1.4"
 }
 
-def releaseDirectory = layout.buildDirectory.dir("release")
-
 tasks.register("packageBoms", Zip) {
     archiveFileName.set("software-bill-of-materials.zip")
-    destinationDirectory.set(releaseDirectory)
     from(cyclonedxBom.outputs){
         include ("bom.*")
     }
@@ -61,5 +58,6 @@ tasks.register("packageBoms", Zip) {
 tasks.register("release", Copy) {
     dependsOn packageBoms
     from(bootJar.outputs)
-    into(releaseDirectory)
+    from(packageBoms.outputs)
+    into(layout.buildDirectory.dir("release"))
 }


### PR DESCRIPTION
Only one task needs to know about the target directory 'build/release'